### PR TITLE
GraalVM version updated

### DIFF
--- a/.github/workflows/release-build-native-linux.yml
+++ b/.github/workflows/release-build-native-linux.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install graalvm
       uses: DeLaGuardo/setup-graalvm@3
       with:
-        graalvm-version: '20.0.0.java11'
+        graalvm-version: '20.2.0.java11'
     - name: Install native-image
       run: gu install native-image
     - name: Set version
@@ -53,7 +53,7 @@ jobs:
       - name: Install graalvm
         uses: DeLaGuardo/setup-graalvm@3
         with:
-          graalvm-version: '20.0.0.java11'
+          graalvm-version: '20.2.0.java11'
       - name: Install native-image
         run: gu install native-image
       - name: Set version

--- a/.github/workflows/release-build-native-macos.yml
+++ b/.github/workflows/release-build-native-macos.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install graalvm
       uses: DeLaGuardo/setup-graalvm@3
       with:
-        graalvm-version: '20.0.0.java11'
+        graalvm-version: '20.2.0.java11'
     - name: Install native-image
       run: gu install native-image
     - name: Set version
@@ -54,7 +54,7 @@ jobs:
       - name: Install graalvm
         uses: DeLaGuardo/setup-graalvm@3
         with:
-          graalvm-version: '20.0.0.java11'
+          graalvm-version: '20.2.0.java11'
       - name: Install native-image
         run: gu install native-image
       - name: Set version

--- a/.github/workflows/release-build-native-win64.yml
+++ b/.github/workflows/release-build-native-win64.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install graalvm
       uses: DeLaGuardo/setup-graalvm@3
       with:
-        graalvm-version: '20.0.0.java11'
+        graalvm-version: '20.2.0.java11'
     - name: Install native-image
       run: |
         %JAVA_HOME%/bin/gu.cmd install native-image
@@ -64,7 +64,7 @@ jobs:
       - name: Install graalvm
         uses: DeLaGuardo/setup-graalvm@3
         with:
-          graalvm-version: '20.0.0.java11'
+          graalvm-version: '20.2.0.java11'
       - name: Install native-image
         run: |
           %JAVA_HOME%/bin/gu.cmd install native-image

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Install graalvm
       uses: DeLaGuardo/setup-graalvm@3
       with:
-        graalvm-version: '20.0.0.java11'
+        graalvm-version: '20.2.0.java11'
     
     # Install Native Image,Set Version and Build from Linux and MACOS
     - if: matrix.os != 'windows-2019' 


### PR DESCRIPTION
- Updated GraalVM version to 20.2.0 because Quarkus Doesn't supports the previous versions anymore !