### PR TITLE
Trigger Picocli Help on receiving empty args 

### DIFF
--- a/cli/Readme.md
+++ b/cli/Readme.md
@@ -1,0 +1,7 @@
+# Frequently used Commands used while development: 
+
+### Development mode:
+/mvnw compile quarkus:dev 
+
+Running with Arguments:
+/mvnw compile quarkus:dev -Dquarkus.args="some arguments here"

--- a/cli/src/main/java/dev/starfix/Starfix.java
+++ b/cli/src/main/java/dev/starfix/Starfix.java
@@ -125,7 +125,6 @@ public class Starfix implements Runnable{
     public void run() {
         if(uri==null||uri.isEmpty())
         {   
-            System.out.println("\n === No/Empty Arguments received === ");
             new CommandLine(new Starfix()).usage(System.out); // Will invoke Picocli Help
             return;
         }

--- a/cli/src/main/java/dev/starfix/Starfix.java
+++ b/cli/src/main/java/dev/starfix/Starfix.java
@@ -124,10 +124,11 @@ public class Starfix implements Runnable{
     @Override
     public void run() {
         if(uri==null||uri.isEmpty())
-            {
-                System.out.println("Empty args..");
-                return;
-            }
+        {   
+            System.out.println("Empty Arguments received");
+            new CommandLine(new Starfix()).usage(System.out); // Will invoke Picocli Help
+            return;
+        }
         cloneCmd(uri);
     }
 

--- a/cli/src/main/java/dev/starfix/Starfix.java
+++ b/cli/src/main/java/dev/starfix/Starfix.java
@@ -125,7 +125,7 @@ public class Starfix implements Runnable{
     public void run() {
         if(uri==null||uri.isEmpty())
         {   
-            System.out.println("Empty Arguments received");
+            System.out.println("\n === No/Empty Arguments received === ");
             new CommandLine(new Starfix()).usage(System.out); // Will invoke Picocli Help
             return;
         }


### PR DESCRIPTION
- Trigger Picocli Help on receiving empty args .
- Add commonly used command in  a new readme file in CLI folder. 
Linked Issue: https://github.com/starfixdev/starfix/issues/60