### PR TITLE
fix: use library for exec to remove boilerplate code

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -53,6 +53,11 @@
       <artifactId>jackson-dataformat-yaml</artifactId>
       <version>2.9.2</version>
     </dependency>
+      <dependency>
+          <groupId>org.zeroturnaround</groupId>
+          <artifactId>zt-exec</artifactId>
+          <version>1.12</version>
+      </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/cli/src/test/java/dev/starfix/StarfixTest.java
+++ b/cli/src/test/java/dev/starfix/StarfixTest.java
@@ -41,7 +41,8 @@ public class StarfixTest {
     public void testEcho()throws Exception {
         Path directory = Paths.get(System.getProperty( "user.home" ));
         String test_string="This is some random String that I want to Echo";
-        assertEquals(test_string,runCommand(directory,"echo",test_string),"Echo Random String");
+        String result = runCommand(directory,"echo",test_string);
+        assertEquals(test_string+"\n",result,"Echo Random String");
     }
 
   

--- a/cli/src/test/java/dev/starfix/StarfixTest.java
+++ b/cli/src/test/java/dev/starfix/StarfixTest.java
@@ -42,7 +42,7 @@ public class StarfixTest {
         Path directory = Paths.get(System.getProperty( "user.home" ));
         String test_string="This is some random String that I want to Echo";
         String result = runCommand(directory,"echo",test_string);
-        assertEquals(test_string+"\n",result,"Echo Random String");
+        assertEquals(test_string+System.lineSeparator(),result,"Echo Random String");
     }
 
   


### PR DESCRIPTION
I used this jt-exec library with great success in jbang and it 
greatly simplifies the code so think it would be a good change.

only tested on osx but should work same on linux and windows.

@fahad-israr can you verify it still works for you on linux/windows ?