### PR TITLE
feat: have all config via cli and have default provide for picocli

### DIFF
--- a/cli/src/main/java/dev/starfix/Starfix.java
+++ b/cli/src/main/java/dev/starfix/Starfix.java
@@ -4,6 +4,7 @@
 //DEPS io.quarkus:quarkus-picocli:2.1.0.CR1
 //DEPS org.zeroturnaround:zt-exec:1.12
 //FILES application.properties=../../../resources/application.properties
+//SOURCES YAMLDefaultProvider.java
 
 package dev.starfix;
 import io.quarkus.runtime.annotations.RegisterForReflection;
@@ -23,18 +24,26 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.io.File;
+import java.util.Properties;
 import java.util.concurrent.TimeoutException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
-@CommandLine.Command(mixinStandardHelpOptions = true)
+@CommandLine.Command(name = "starfix", mixinStandardHelpOptions = true, defaultValueProvider = YAMLDefaultProvider.class)
 public class Starfix implements Runnable{
 
     @Parameters(arity = "0..1")
     String uri;
-    
+
+    // Holds path to destination Where the Repository Must Be Clonned
+    @CommandLine.Option(names = "--clone-path", descriptionKey = "clone_path")
+    String clone_path;
+
+    @CommandLine.Option(names = "--editor", descriptionKey = "ide")
+    String ide = ""; // Holds command for IDE to open
+
     @Command
     public int config() throws Exception {
         editConfig();
@@ -55,31 +64,13 @@ public class Starfix implements Runnable{
             throw new IllegalArgumentException("Not a valid URI for git repository");
         }
 
-        // Configuration identifiers
-        String clone_path = "";// Holds path to destination Where the Repository Must Be Clonned
-        String ide = ""; // Holds command for IDE to open upon
 
-        File configFile = getConfigFile();// Calling functiono to fetch config file
+        if(ide==null) {
+            throw new IllegalArgumentException("Editor not specifed, please specify via --editor or use config to set it up.");
+        }
 
-        // Reading Configuration File
-        try {
-            if (!configFile.exists()) {
-                // Incase no config file exists
-                editConfig(); // Calling function that lets user to configure
-            }
-
-            // System.out.println("\nLoading configurations.....\n");
-            ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
-
-            Config config = mapper.readValue(configFile, Config.class);
-
-            ide = config.ide;
-            clone_path = config.clone_path;
-            if (ide == null || clone_path == null)
-                editConfig(); // Incase of absence of configuration in file Launch Config
-
-        } catch (Exception e) {
-            e.printStackTrace();
+        if(clone_path==null) {
+            throw new IllegalArgumentException("Clone path not specifed, please specify via --clone-path or use config to set it up.");
         }
 
         try {
@@ -221,7 +212,9 @@ public class Starfix implements Runnable{
             }
             // ----------Now we'll write configurations to the YAML FILE------------
             ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
-            Config configuration = new Config(ide, clone_path);
+            Properties configuration = new Properties();
+            configuration.put("ide", ide);
+            configuration.put("clone_path", clone_path);
             mapper.writeValue(configFile, configuration); // Writing to YAML File
 
         } catch (Exception e) {
@@ -255,38 +248,6 @@ public class Starfix implements Runnable{
         return presult.outputUTF8();
     }
 
-    @RegisterForReflection
-    public static class Config {
-        public String ide;
-        public String clone_path;
-
-        public Config() {
-            // Default constructor
-        }
-
-        public Config(String ide, String clone_path) {
-            this.ide = ide;
-            this.clone_path = clone_path;
-
-        }
-
-        public String getIde() {
-            return ide;
-        }
-
-        public void setIde(String ide) {
-            this.ide = ide;
-        }
-
-        public String getClone_path() {
-            return clone_path;
-        }
-
-        public void setClone_path(String clone_path) {
-            this.clone_path = clone_path;
-        }
-
-    }
 
     public static void launch_editor(Path directory, String ide, String path, String filePath) throws IOException, InterruptedException {
 

--- a/cli/src/main/java/dev/starfix/Starfix.java
+++ b/cli/src/main/java/dev/starfix/Starfix.java
@@ -7,7 +7,6 @@
 //SOURCES YAMLDefaultProvider.java
 
 package dev.starfix;
-import io.quarkus.runtime.annotations.RegisterForReflection;
 import org.zeroturnaround.exec.ProcessExecutor;
 import org.zeroturnaround.exec.ProcessResult;
 import picocli.CommandLine;
@@ -26,7 +25,6 @@ import java.util.Arrays;
 import java.io.File;
 import java.util.Properties;
 import java.util.concurrent.TimeoutException;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
@@ -103,7 +101,7 @@ public class Starfix implements Runnable{
             filePath = Paths.get(clone_path,repo_name,filePath).toAbsolutePath().toString();
 
             // Launching Editor on the Cloned Directory
-            System.out.println("Launching  Editor Now...");
+            System.out.println("Opening " + filePath);
             launch_editor(directory, ide, directory.toAbsolutePath().toString(),filePath);
         } catch (Exception e) {
             throw new IllegalStateException(e);
@@ -226,13 +224,14 @@ public class Starfix implements Runnable{
 
     public static void gitClone(Path directory, String originUrl) throws IOException, InterruptedException {
         // Function for git clonning
-        runCommand(directory.getParent(), "git", "clone", originUrl, directory.getFileName().toString());
+        runCommand(directory.getParent(), "git", "clone", originUrl, directory.toString());
     }
 
     public static String runCommand(Path directory, String... command) throws IOException, InterruptedException {
         // Function to Run Commands using Process Builder
         ProcessResult presult;
         try {
+            System.out.println("Running " + String.join(" ", command));
             presult = new ProcessExecutor().command(command).redirectOutput(System.out).redirectErrorStream(true).readOutput(true)
                     .execute();
         } catch (TimeoutException e) {

--- a/cli/src/main/java/dev/starfix/YAMLDefaultProvider.java
+++ b/cli/src/main/java/dev/starfix/YAMLDefaultProvider.java
@@ -1,0 +1,204 @@
+package dev.starfix;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import picocli.CommandLine;
+import picocli.CommandLine.IDefaultValueProvider;
+import picocli.CommandLine.Model.ArgSpec;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Model.OptionSpec;
+import picocli.CommandLine.Model.PositionalParamSpec;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.Reader;
+import java.util.Properties;
+
+/**
+ * {@link IDefaultValueProvider IDefaultValueProvider} implementation that loads default values for command line
+ * options and positional parameters from a properties file or {@code Properties} object.
+ * <h2>Location</h2>
+ * By default, this implementation tries to find a properties file named
+ * {@code ".<YOURCOMMAND>.properties"} in the user home directory, where {@code "<YOURCOMMAND>"} is the {@linkplain CommandLine.Command#name() name} of the command.
+ * If a command has {@linkplain CommandLine.Command#aliases() aliases} in addition to its {@linkplain CommandLine.Command#name() name},
+ * these aliases are also used to try to find the properties file. For example:
+ * <pre>{@code
+ * @Command(name = "git", defaultValueProvider = YAMLDefaultProvider.class)
+ * class Git { }
+ * }</pre>
+ * <p>The above will try to load default values from {@code new File(System.getProperty("user.home"), ".git.properties")}.
+ * </p>
+ * <p>
+ * The location of the properties file can also be controlled with system property {@code "picocli.defaults.<YOURCOMMAND>.path"},
+ * in which case the value of the property must be the path to the file containing the default values.
+ * </p>
+ * <p>
+ * The location of the properties file may also be specified programmatically. For example:
+ * </p>
+ * <pre>
+ * CommandLine cmd = new CommandLine(new MyCommand());
+ * File defaultsFile = new File("path/to/config/mycommand.properties");
+ * cmd.setDefaultValueProvider(new YAMLDefaultProvider(defaultsFile));
+ * cmd.execute(args);
+ * </pre>
+ * <h2>Format</h2>
+ * <p>
+ * For options, the key is either the {@linkplain CommandLine.Option#descriptionKey() descriptionKey},
+ * or the option's {@linkplain OptionSpec#longestName() longest name}.
+ * </p><p>
+ * For positional parameters, the key is either the
+ * {@linkplain CommandLine.Parameters#descriptionKey() descriptionKey},
+ * or the positional parameter's {@linkplain PositionalParamSpec#paramLabel() param label}.
+ * </p><p>
+ * End users may not know what the {@code descriptionKey} of your options and positional parameters are, so be sure
+ * to document that with your application.
+ * </p>
+ * <h2>Subcommands</h2>
+ * <p>
+ * The default values for options and positional parameters of subcommands can be included in the
+ * properties file for the top-level command, so that end users need to maintain only a single file.
+ * This can be achieved by prefixing the key with the command's qualified name.
+ * For example, to give the {@code `git commit`} command's {@code --cleanup} option a
+ * default value of {@code strip}, define a key of {@code git.commit.cleanup} and assign
+ * it a default value.
+ * </p><pre>
+ * # /home/remko/.git.properties
+ * git.commit.cleanup = strip
+ * </pre>
+ */
+public class YAMLDefaultProvider implements IDefaultValueProvider {
+
+    private Properties properties;
+
+    /**
+     * Default constructor, used when this default value provider is specified in
+     * the annotations:
+     * <pre>
+     * {@code
+     * @Command(name = "mycmd",
+     *     defaultValueProvider = YAMLDefaultProvider.class)
+     * class MyCommand // ...
+     * }
+     * </pre>
+     * <p>
+     * This loads default values from a properties file named
+     * {@code ".mycmd.properties"} in the user home directory.
+     * </p><p>
+     * The location of the properties file can also be controlled with system property {@code "picocli.defaults.<YOURCOMMAND>.path"},
+     * in which case the value of the property must be the path to the file containing the default values.
+     * </p>
+     * @see YAMLDefaultProvider the YAMLDefaultProvider class description
+     */
+    public YAMLDefaultProvider() {}
+
+    /**
+     * This constructor loads default values from the specified properties object.
+     * This may be used programmatically. For example:
+     * <pre>
+     * CommandLine cmd = new CommandLine(new MyCommand());
+     * Properties defaults = getProperties();
+     * cmd.setDefaultValueProvider(new YAMLDefaultProvider(defaults));
+     * cmd.execute(args);
+     * </pre>
+     * @param properties the properties containing the default values
+     * @see YAMLDefaultProvider the YAMLDefaultProvider class description
+     */
+    public YAMLDefaultProvider(Properties properties) {
+        this.properties = properties;
+    }
+
+    /**
+     * This constructor loads default values from the specified properties file.
+     * This may be used programmatically. For example:
+     * <pre>
+     * CommandLine cmd = new CommandLine(new MyCommand());
+     * File defaultsFile = new File("path/to/config/file.properties");
+     * cmd.setDefaultValueProvider(new YAMLDefaultProvider(defaultsFile));
+     * cmd.execute(args);
+     * </pre>
+     * @param file the file to load default values from. Must be non-{@code null} and
+     *             must contain default values in the standard java {@link Properties} format.
+     * @see YAMLDefaultProvider the YAMLDefaultProvider class description
+     */
+    public YAMLDefaultProvider(File file) {
+        this(createProperties(file));
+    }
+
+    private static Properties createProperties(File file) {
+        if (file == null) {
+            throw new NullPointerException("file is null");
+        }
+
+        Properties result = new Properties();
+        if (file.exists() && file.canRead()) {
+
+            try {
+                ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+                Properties config = mapper.readValue(file, Properties.class);
+                result.putAll(config);
+            } catch (IOException ioe) {
+                System.err.println("WARN - could not read defaults from " + file.getAbsolutePath() + ": " + ioe);
+            }
+        } else {
+            System.err.println("WARN - defaults configuration file " + file.getAbsolutePath() + " does not exist or is not readable");
+        }
+        return result;
+    }
+
+    private static Properties loadProperties(CommandSpec commandSpec) {
+        if (commandSpec == null) { return null; }
+        Properties p = System.getProperties();
+        for (String name : commandSpec.names()) {
+            String path = p.getProperty("picocli.defaults." + name + ".path");
+            File defaultPath = new File(p.getProperty("user.home") + File.separator + "/.config", name + ".yaml");
+            File file = path == null ? defaultPath : new File(path);
+            if (file.canRead()) {
+                return createProperties(file);
+            }
+        }
+        return loadProperties(commandSpec.parent());
+    }
+
+    @Override
+    public String defaultValue(ArgSpec argSpec) throws Exception {
+        if (properties == null) {
+            properties = loadProperties(argSpec.command());
+        }
+        if (properties == null || properties.isEmpty()) {
+            return null;
+        }
+        return argSpec.isOption()
+                ? optionDefaultValue((OptionSpec) argSpec)
+                : positionalDefaultValue((PositionalParamSpec) argSpec);
+    }
+
+    private String optionDefaultValue(OptionSpec option) {
+        String result = getValue(option.descriptionKey(), option.command());
+        result = result != null ? result : getValue(stripPrefix(option.longestName()), option.command());
+        return result;
+    }
+    private static String stripPrefix(String prefixed) {
+        for (int i = 0; i < prefixed.length(); i++) {
+            if (Character.isJavaIdentifierPart(prefixed.charAt(i))) {
+                return prefixed.substring(i);
+            }
+        }
+        return prefixed;
+    }
+
+    private String positionalDefaultValue(PositionalParamSpec positional) {
+        String result = getValue(positional.descriptionKey(), positional.command());
+        result = result != null ? result : getValue(positional.paramLabel(), positional.command());
+        return result;
+    }
+
+    private String getValue(String key, CommandSpec spec) {
+        String result = null;
+        if (spec != null) {
+            String cmd = spec.qualifiedName(".");
+            result = properties.getProperty(cmd + "." + key);
+        }
+        return result != null ? result : properties.getProperty(key);
+    }
+}


### PR DESCRIPTION
I got tired of having to edit the config to try things out so changed
config reading to be default provider for picocli so config will provide
defaults but you can override with command line arguments.