### PR TITLE
Specify URL Scheme ide://

### DIFF
--- a/cli/installer/macos/installer/starfix-urlhandler.applescript
+++ b/cli/installer/macos/installer/starfix-urlhandler.applescript
@@ -1,5 +1,5 @@
 on open location this_URL
-	set AppleScript's text item delimiters to ":"
+	set AppleScript's text item delimiters to "ide://"
 	set uri_elements to every text item of this_URL
 	set protocol to item 1 of uri_elements
 	set the script_file to POSIX path of (path to resource "starfix")


### PR DESCRIPTION
- ~~I figured out that the URI Scheme was missing.~~
- ~~Specifying the URL Scheme does try launch starfix application(tested on macos Catalina 10.15.7).~~
- The problem that still remains is that I am unable to launch the Starfix application on mac (after moving starfix to application folder).
- One might wonder that if the application doesn't launch then how am I concluding that this ide:// scheme handler works ?? Well, on hitting `open ide://somtxt` on the Terminal I can see starfix application bouncing on my Dock at the bottom (The same behaviour which happens when I try  to open the starfix application directly) 
- Another thing I was wondering is that could we run the `build.sh` script beforehand while the installer is being generated(through gh-actions) . This is a low priority concern but I was just thinking about it so that the user gets the `starfix.app` directly which he can directly move to applications folder. (I am not sure if the output of `build.sh` is system dependant: if yes then this point is of no use)